### PR TITLE
Overhaul asset representation (v0.2.0)

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -6,3 +6,9 @@ version = "0.1.0"
 [deps]
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"
 Reexport = "189a3867-3050-52da-a836-e630ba90ab69"
+
+[extras]
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+
+[targets]
+test = ["Test"]

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "PRASBase"
 uuid = "b5ddb534-8618-11e9-23a2-3523bd004218"
 authors = ["Gord Stephen <gord.stephen@nrel.gov>"]
-version = "0.1.0"
+version = "0.2.0"
 
 [deps]
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"

--- a/README.md
+++ b/README.md
@@ -1,0 +1,7 @@
+# PRASBase
+
+Core data structures for defining power systems in
+[PRAS](https://github.com/NREL/PRAS).
+Can also be used standalone to read or write PRAS-compatible systems as part of
+a conversion process to/from some other system representation (e.g.
+[PLEXOS2PRAS](https://github.com/NREL/PLEXOS2PRAS.jl)).

--- a/src/PRASBase.jl
+++ b/src/PRASBase.jl
@@ -7,10 +7,9 @@ using Reexport
 export
 
     # System assets
-    AssetSpec,
-    DispatchableGeneratorSpec,
-    StorageDeviceSpec,
-    LineSpec,
+    AbstractAssets,
+    Regions, Interfaces,
+    Generators, Storages, GeneratorStorages, Lines,
 
     # Units
     PowerUnit, MW, GW,

--- a/src/PRASBase.jl
+++ b/src/PRASBase.jl
@@ -21,6 +21,7 @@ export
     SystemModel
 
 include("units.jl")
+include("collections.jl")
 include("assets.jl")
 include("SystemModel.jl")
 

--- a/src/SystemModel.jl
+++ b/src/SystemModel.jl
@@ -1,12 +1,12 @@
 struct SystemModel{N,L,T<:Period,P<:PowerUnit,E<:EnergyUnit}
 
-    regions::Regions{P}
-    generators::Generators{L,T,P}
-    storages::Storages{L,T,P,E}
-    generatorstorages::GeneratorStorages{L,T,P,E}
+    regions::Regions{N,P}
+    generators::Generators{N,L,T,P}
+    storages::Storages{N,L,T,P,E}
+    generatorstorages::GeneratorStorages{N,L,T,P,E}
 
-    interfaces::Interfaces{P}
-    lines::Lines{L,T,P}
+    interfaces::Interfaces{N,P}
+    lines::Lines{N,L,T,P}
 
     # starting index of each region in the generator vector
     # e.g. for region i, corresponding generators are stored in
@@ -59,8 +59,10 @@ struct SystemModel{N,L,T<:Period,P<:PowerUnit,E<:EnergyUnit}
 
         @assert length(lines_interfacestart) == n_interfaces
         @assert issorted(lines_interfacestart)
-        @assert first(lines_interfacestart) == 1
-        n_lines > 0 && @assert lines_interfacestart[end] <= n_lines + 1
+        if n_lines > 0
+            @assert first(lines_interfacestart) == 1
+            @assert lines_interfacestart[end] <= n_lines + 1
+        end
 
         @assert all(
             1 <= interfaces.regions_from[i] < interfaces.regions_to[i] <= n_regions
@@ -87,7 +89,7 @@ function SystemModel{N,L,T,P,E}(
     generatorstorages::GeneratorStorages{N,L,T,P,E},
     timestamps::StepRange{DateTime,T},
     load::Vector{Int}
-) where {N,L,T<:Period,P<:PowerUnit,E<:EnergyUnit,V<:Real}
+) where {N,L,T<:Period,P<:PowerUnit,E<:EnergyUnit}
 
     return SystemModel{N,L,T,P,E}(
         Regions{N,P}(["Region"], reshape(load, 1, :)),

--- a/src/SystemModel.jl
+++ b/src/SystemModel.jl
@@ -1,32 +1,24 @@
 struct SystemModel{N,L,T<:Period,P<:PowerUnit,E<:EnergyUnit,V<:Real}
 
-    regions::Vector{String} # region names
+    regions::Regions{P}
+    generators::Generators{L,T,P}
+    storages::Storages{L,T,P,E}
+    generatorstorages::GeneratorStorages{L,T,P,E}
 
-    generators::Matrix{DispatchableGeneratorSpec{V}} # generators x unique sets
-    generators_regionstart::Vector{Int} # starting index of each region
-                                        # in the generator vector
-    # e.g. for region i, corresponding units are stored in
+    interfaces::Interfaces
+    lines::Lines{L,T,P}
+
+    # starting index of each region in the generator vector
+    # e.g. for region i, corresponding generators are stored in
     # generators[generators_regionstart[i]:generators_regionsstart[i+1]-1]
     # (in the last region i == length(regions), it would be
     # generators[generators_regionstart[i]:end])
-
-    storages::Matrix{StorageDeviceSpec{V}} # devices x unique sets
-    storages_regionstart::Vector{Int} # starting index of each region
-                                      # in the storage device vector
-
-    interfaces::Vector{Tuple{Int,Int}}
-
-    lines::Matrix{LineSpec{V}} # lines x unique sets
-    lines_interfacestart::Vector{Int} # starting index of each line
-                                      # in the line vector
+    generators_regionstart::Vector{Int}
+    storages_regionstart::Vector{Int}
+    generatorstorages_regionstart::Vector{Int}
+    lines_interfacestart::Vector{Int}
 
     timestamps::StepRange{DateTime,T}
-    timestamps_generatorset::Vector{Int} # generator property set for each timestamp
-    timestamps_storageset::Vector{Int} # storage device property set for each timestamp
-    timestamps_lineset::Vector{Int} # line property set for each timestamp
-
-    vg::Matrix{V} # regions x timestamps
-    load::Matrix{V} # regions x timestamps
 
     function SystemModel{N,L,T,P,E}(
         regions::Vector{String},

--- a/src/assets.jl
+++ b/src/assets.jl
@@ -1,5 +1,5 @@
 abstract type AbstractAssets{N,L,T<:Period,P<:PowerUnit} end
-length(a::AbstractAssets) = length(a.names)
+Base.length(a::AbstractAssets) = length(a.names)
 
 struct Generators{N,L,T<:Period,P<:PowerUnit} <: AbstractAssets{N,L,T,P}
 
@@ -16,8 +16,9 @@ struct Generators{N,L,T<:Period,P<:PowerUnit} <: AbstractAssets{N,L,T,P}
         capacity::Matrix{Int}, λ::Matrix{Float64}, μ::Matrix{Float64}
     ) where {N,L,T,P}
 
-        n_gens = length(name)
-        @assert length(category) == n_gens
+        n_gens = length(names)
+        @assert length(categories) == n_gens
+        @assert allunique(names)
 
         @assert size(capacity) == (n_gens, N)
         @assert all(capacity .>= 0) # Why not just use unsigned integers?
@@ -51,13 +52,14 @@ struct Storages{N,L,T<:Period,P<:PowerUnit,E<:EnergyUnit} <: AbstractAssets{N,L,
     function Storages{N,L,T,P,E}(
         names::Vector{String}, categories::Vector{String},
         chargecapacity::Matrix{Int}, dischargecapacity::Matrix{Int},
-        energycapacity::Matrix{Int}, chargeefficiency::Matrix{Int},
+        energycapacity::Matrix{Int}, chargeefficiency::Matrix{Float64},
         dischargeefficiency::Matrix{Float64}, carryoverefficiency::Matrix{Float64},
         λ::Matrix{Float64}, μ::Matrix{Float64}
     ) where {N,L,T,P,E}
 
         n_stors = length(names)
         @assert length(categories) == n_stors
+        @assert allunique(names)
 
         @assert size(chargecapacity) == (n_stors, N)
         @assert size(dischargecapacity) == (n_stors, N)
@@ -78,10 +80,10 @@ struct Storages{N,L,T<:Period,P<:PowerUnit,E<:EnergyUnit} <: AbstractAssets{N,L,
         @assert all(0 .<= λ .<= 1)
         @assert all(0 .<= μ .<= 1)
 
-        new{N,L,T,P,E}(name, category,
-                     chargecapacity, dischargecapacity, energycapacity,
-                     chargeefficiency, dischargeefficiency, carryoverefficiency,
-                     λ, μ)
+        new{N,L,T,P,E}(names, categories,
+                       chargecapacity, dischargecapacity, energycapacity,
+                       chargeefficiency, dischargeefficiency, carryoverefficiency,
+                       λ, μ)
 
     end
 
@@ -106,16 +108,17 @@ struct GeneratorStorages{N,L,T<:Period,P<:PowerUnit,E<:EnergyUnit} <: AbstractAs
     μ::Matrix{Float64}
 
     function GeneratorStorages{N,L,T,P,E}(
-        name::Vector{String}, category::Vector{String}, inflowcapacity::Matrix{Int},
+        names::Vector{String}, categories::Vector{String}, inflowcapacity::Matrix{Int},
         chargecapacity::Matrix{Int}, dischargecapacity::Matrix{Int},
         storage_chargecapacity::Matrix{Int}, storage_dischargecapacity::Matrix{Int},
-        storage_energycapacity::Matrix{Int}, storage_chargeefficiency::Matrix{Int},
+        storage_energycapacity::Matrix{Int}, storage_chargeefficiency::Matrix{Float64},
         storage_dischargeefficiency::Matrix{Float64}, storage_carryoverefficiency::Matrix{Float64},
         λ::Matrix{Float64}, μ::Matrix{Float64}
     ) where {N,L,T,P,E}
 
         n_stors = length(names)
         @assert length(categories) == n_stors
+        @assert allunique(names)
 
         @assert size(inflowcapacity) == (n_stors, N)
         @assert size(chargecapacity) == (n_stors, N)
@@ -143,7 +146,7 @@ struct GeneratorStorages{N,L,T<:Period,P<:PowerUnit,E<:EnergyUnit} <: AbstractAs
         @assert all(0 .<= λ .<= 1)
         @assert all(0 .<= μ .<= 1)
 
-        new{N,L,T,P,E}(name, category,
+        new{N,L,T,P,E}(names, categories,
                        inflowcapacity, chargecapacity, dischargecapacity,
                        storage_chargecapacity, storage_dischargecapacity,
                        storage_energycapacity,
@@ -174,6 +177,7 @@ struct Lines{N,L,T<:Period,P<:PowerUnit} <: AbstractAssets{N,L,T,P}
 
         n_lines = length(names)
         @assert length(categories) == n_lines
+        @assert allunique(names)
 
         @assert size(forwardcapacity) == (n_lines, N)
         @assert size(backwardcapacity) == (n_lines, N)
@@ -185,7 +189,7 @@ struct Lines{N,L,T<:Period,P<:PowerUnit} <: AbstractAssets{N,L,T,P}
         @assert all(0 .<= λ .<= 1)
         @assert all(0 .<= μ .<= 1)
 
-        new{N,L,T,P}(name, category, forwardcapacity, backwardcapacity, λ, μ)
+        new{N,L,T,P}(names, categories, forwardcapacity, backwardcapacity, λ, μ)
 
     end
 

--- a/src/assets.jl
+++ b/src/assets.jl
@@ -1,42 +1,42 @@
-abstract type AbstractAssets{L,T<:Period,P<:PowerUnit} end
+abstract type AbstractAssets{N,L,T<:Period,P<:PowerUnit} end
+length(a::AbstractAssets) = length(a.names)
 
-struct Generators{L,T<:Period,P<:PowerUnit} <: AbstractAssets{L,T,P}
+struct Generators{N,L,T<:Period,P<:PowerUnit} <: AbstractAssets{N,L,T,P}
 
-    name::Vector{String}
-    category::Vector{String}
+    names::Vector{String}
+    categories::Vector{String}
 
     capacity::Matrix{Int} # power
 
     λ::Matrix{Float64}
     μ::Matrix{Float64}
 
-    function Generators{L,T,P}(
-        name::Vector{String}, category::Vector{String},
+    function Generators{N,L,T,P}(
+        names::Vector{String}, categories::Vector{String},
         capacity::Matrix{Int}, λ::Matrix{Float64}, μ::Matrix{Float64}
-    ) where {L,T,P}
+    ) where {N,L,T,P}
 
         n_gens = length(name)
-        n_periods = size(capacity, 2)
-
         @assert length(category) == n_gens
-        @assert size(capacity) == (n_gens, n_periods)
+
+        @assert size(capacity) == (n_gens, N)
         @assert all(capacity .>= 0) # Why not just use unsigned integers?
 
-        @assert size(λ) == (n_gens, n_periods)
-        @assert size(μ) == (n_gens, n_periods)
+        @assert size(λ) == (n_gens, N)
+        @assert size(μ) == (n_gens, N)
         @assert all(0 .<= λ .<= 1)
         @assert all(0 .<= μ .<= 1)
 
-        new{L,T,P}(name, category, capacity, λ, μ)
+        new{N,L,T,P}(names, categories, capacity, λ, μ)
 
     end
 
 end
 
-struct Storages{L,T<:Period,P<:PowerUnit,E<:EnergyUnit} <: AbstractAssets{L,T,P}
+struct Storages{N,L,T<:Period,P<:PowerUnit,E<:EnergyUnit} <: AbstractAssets{N,L,T,P}
 
-    name::Vector{String}
-    category::Vector{String}
+    names::Vector{String}
+    categories::Vector{String}
 
     chargecapacity::Matrix{Int} # power
     dischargecapacity::Matrix{Int} # power
@@ -48,39 +48,37 @@ struct Storages{L,T<:Period,P<:PowerUnit,E<:EnergyUnit} <: AbstractAssets{L,T,P}
     λ::Matrix{Float64}
     μ::Matrix{Float64}
 
-    function Storages{L,T,P,E}(
-        name::Vector{String}, category::Vector{String},
+    function Storages{N,L,T,P,E}(
+        names::Vector{String}, categories::Vector{String},
         chargecapacity::Matrix{Int}, dischargecapacity::Matrix{Int},
         energycapacity::Matrix{Int}, chargeefficiency::Matrix{Int},
         dischargeefficiency::Matrix{Float64}, carryoverefficiency::Matrix{Float64},
         λ::Matrix{Float64}, μ::Matrix{Float64}
-    ) where {L,T,P,E}
+    ) where {N,L,T,P,E}
 
-        n_stors = length(name)
-        n_periods = size(capacity, 2)
+        n_stors = length(names)
+        @assert length(categories) == n_stors
 
-        @assert length(category) == n_gens
-
-        @assert size(chargecapacity) == (n_gens, n_periods)
-        @assert size(dischargecapacity) == (n_gens, n_periods)
-        @assert size(energycapacity) == (n_gens, n_periods)
+        @assert size(chargecapacity) == (n_stors, N)
+        @assert size(dischargecapacity) == (n_stors, N)
+        @assert size(energycapacity) == (n_stors, N)
         @assert all(chargecapacity .>= 0)
         @assert all(dischargecapacity .>= 0)
         @assert all(energycapacity .>= 0)
 
-        @assert size(chargeefficiency) == (n_gens, n_periods)
-        @assert size(dischargeefficiency) == (n_gens, n_periods)
-        @assert size(carryoverefficiency) == (n_gens, n_periods)
+        @assert size(chargeefficiency) == (n_stors, N)
+        @assert size(dischargeefficiency) == (n_stors, N)
+        @assert size(carryoverefficiency) == (n_stors, N)
         @assert all(0 .<= chargeefficiency .<= 1)
         @assert all(0 .<= dischargeefficiency .<= 1)
         @assert all(0 .<= carryoverefficiency .<= 1)
 
-        @assert size(λ) == (n_gens, n_periods)
-        @assert size(μ) == (n_gens, n_periods)
+        @assert size(λ) == (n_stors, N)
+        @assert size(μ) == (n_stors, N)
         @assert all(0 .<= λ .<= 1)
         @assert all(0 .<= μ .<= 1)
 
-        new{L,T,P,E}(name, category,
+        new{N,L,T,P,E}(name, category,
                      chargecapacity, dischargecapacity, energycapacity,
                      chargeefficiency, dischargeefficiency, carryoverefficiency,
                      λ, μ)
@@ -89,10 +87,10 @@ struct Storages{L,T<:Period,P<:PowerUnit,E<:EnergyUnit} <: AbstractAssets{L,T,P}
 
 end
 
-struct GeneratorStorages{L,T<:Period,P<:PowerUnit,E<:EnergyUnit} <: AbstractAssets{L,T,P}
+struct GeneratorStorages{N,L,T<:Period,P<:PowerUnit,E<:EnergyUnit} <: AbstractAssets{N,L,T,P}
 
-    name::Vector{String}
-    category::Vector{String}
+    names::Vector{String}
+    categories::Vector{String}
 
     inflowcapacity::Matrix{Int} # power
     chargecapacity::Matrix{Int} # power
@@ -107,62 +105,60 @@ struct GeneratorStorages{L,T<:Period,P<:PowerUnit,E<:EnergyUnit} <: AbstractAsse
     λ::Matrix{Float64}
     μ::Matrix{Float64}
 
-    function GeneratorStorages{L,T,P,E}(
+    function GeneratorStorages{N,L,T,P,E}(
         name::Vector{String}, category::Vector{String}, inflowcapacity::Matrix{Int},
         chargecapacity::Matrix{Int}, dischargecapacity::Matrix{Int},
         storage_chargecapacity::Matrix{Int}, storage_dischargecapacity::Matrix{Int},
         storage_energycapacity::Matrix{Int}, storage_chargeefficiency::Matrix{Int},
         storage_dischargeefficiency::Matrix{Float64}, storage_carryoverefficiency::Matrix{Float64},
         λ::Matrix{Float64}, μ::Matrix{Float64}
-    ) where {L,T,P,E}
+    ) where {N,L,T,P,E}
 
-        n_stors = length(name)
-        n_periods = size(capacity, 2)
+        n_stors = length(names)
+        @assert length(categories) == n_stors
 
-        @assert length(category) == n_gens
-
-        @assert size(inflowcapacity) == (n_gens, n_periods)
-        @assert size(chargecapacity) == (n_gens, n_periods)
-        @assert size(dischargecapacity) == (n_gens, n_periods)
+        @assert size(inflowcapacity) == (n_stors, N)
+        @assert size(chargecapacity) == (n_stors, N)
+        @assert size(dischargecapacity) == (n_stors, N)
         @assert all(inflowcapacity .>= 0)
         @assert all(chargecapacity .>= 0)
         @assert all(dischargecapacity .>= 0)
 
-        @assert size(storage_chargecapacity) == (n_gens, n_periods)
-        @assert size(storage_dischargecapacity) == (n_gens, n_periods)
-        @assert size(storage_energycapacity) == (n_gens, n_periods)
+        @assert size(storage_chargecapacity) == (n_stors, N)
+        @assert size(storage_dischargecapacity) == (n_stors, N)
+        @assert size(storage_energycapacity) == (n_stors, N)
         @assert all(storage_chargecapacity .>= 0)
         @assert all(storage_dischargecapacity .>= 0)
         @assert all(storage_energycapacity .>= 0)
 
-        @assert size(storage_chargeefficiency) == (n_gens, n_periods)
-        @assert size(storage_dischargeefficiency) == (n_gens, n_periods)
-        @assert size(storage_carryoverefficiency) == (n_gens, n_periods)
+        @assert size(storage_chargeefficiency) == (n_stors, N)
+        @assert size(storage_dischargeefficiency) == (n_stors, N)
+        @assert size(storage_carryoverefficiency) == (n_stors, N)
         @assert all(0 .<= storage_chargeefficiency .<= 1)
         @assert all(0 .<= storage_dischargeefficiency .<= 1)
         @assert all(0 .<= storage_carryoverefficiency .<= 1)
 
-        @assert size(λ) == (n_gens, n_periods)
-        @assert size(μ) == (n_gens, n_periods)
+        @assert size(λ) == (n_stors, N)
+        @assert size(μ) == (n_stors, N)
         @assert all(0 .<= λ .<= 1)
         @assert all(0 .<= μ .<= 1)
 
-        new{L,T,P,E}(name, category,
-                     inflowcapacity, chargecapacity, dischargecapacity,
-                     storage_chargecapacity, storage_dischargecapacity,
-                     storage_energycapacity,
-                     storage_chargeefficiency, storage_dischargeefficiency,
-                     storage_carryoverefficiency,
-                     λ, μ)
+        new{N,L,T,P,E}(name, category,
+                       inflowcapacity, chargecapacity, dischargecapacity,
+                       storage_chargecapacity, storage_dischargecapacity,
+                       storage_energycapacity,
+                       storage_chargeefficiency, storage_dischargeefficiency,
+                       storage_carryoverefficiency,
+                       λ, μ)
 
     end
 
 end
 
-struct Lines{L,T<:Period,P<:PowerUnit} <: AbstractAssets{L,T,P}
+struct Lines{N,L,T<:Period,P<:PowerUnit} <: AbstractAssets{N,L,T,P}
 
-    name::Vector{String}
-    category::Vector{String}
+    names::Vector{String}
+    categories::Vector{String}
 
     forwardcapacity::Matrix{Int} # power
     backwardcapacity::Matrix{Int} # power
@@ -170,27 +166,26 @@ struct Lines{L,T<:Period,P<:PowerUnit} <: AbstractAssets{L,T,P}
     λ::Matrix{Float64}
     μ::Matrix{Float64}
 
-    function Lines{L,T,P}(
-        name::Vector{String}, category::Vector{String},
+    function Lines{N,L,T,P}(
+        names::Vector{String}, categories::Vector{String},
         forwardcapacity::Matrix{Int}, backwardcapacity::Matrix{Int},
         λ::Matrix{Float64}, μ::Matrix{Float64}
-    ) where {L,T,P}
+    ) where {N,L,T,P}
 
-        n_gens = length(name)
-        n_periods = size(capacity, 2)
+        n_lines = length(names)
+        @assert length(categories) == n_lines
 
-        @assert length(category) == n_gens
-        @assert size(forwardcapacity) == (n_gens, n_periods)
-        @assert size(backwardcapacity) == (n_gens, n_periods)
+        @assert size(forwardcapacity) == (n_lines, N)
+        @assert size(backwardcapacity) == (n_lines, N)
         @assert all(forwardcapacity .>= 0)
         @assert all(backwardcapacity .>= 0)
 
-        @assert size(λ) == (n_gens, n_periods)
-        @assert size(μ) == (n_gens, n_periods)
+        @assert size(λ) == (n_lines, N)
+        @assert size(μ) == (n_lines, N)
         @assert all(0 .<= λ .<= 1)
         @assert all(0 .<= μ .<= 1)
 
-        new{L,T,P}(name, category, forwardcapacity, backwardcapacity, λ, μ)
+        new{N,L,T,P}(name, category, forwardcapacity, backwardcapacity, λ, μ)
 
     end
 

--- a/src/assets.jl
+++ b/src/assets.jl
@@ -1,23 +1,197 @@
-# Immutable asset specifications
+abstract type AbstractAssets{L,T<:Period,P<:PowerUnit} end
 
-abstract type AssetSpec{T<:Real} end
+struct Generators{L,T<:Period,P<:PowerUnit} <: AbstractAssets{L,T,P}
 
-struct DispatchableGeneratorSpec{T<:Real} <: AssetSpec{T}
-    capacity::T
-    λ::T
-    μ::T
+    name::Vector{String}
+    category::Vector{String}
+
+    capacity::Matrix{Int} # power
+
+    λ::Matrix{Float64}
+    μ::Matrix{Float64}
+
+    function Generators{L,T,P}(
+        name::Vector{String}, category::Vector{String},
+        capacity::Matrix{Int}, λ::Matrix{Float64}, μ::Matrix{Float64}
+    ) where {L,T,P}
+
+        n_gens = length(name)
+        n_periods = size(capacity, 2)
+
+        @assert length(category) == n_gens
+        @assert size(capacity) == (n_gens, n_periods)
+        @assert all(capacity .>= 0) # Why not just use unsigned integers?
+
+        @assert size(λ) == (n_gens, n_periods)
+        @assert size(μ) == (n_gens, n_periods)
+        @assert all(0 .<= λ .<= 1)
+        @assert all(0 .<= μ .<= 1)
+
+        new{L,T,P}(name, category, capacity, λ, μ)
+
+    end
+
 end
 
-struct StorageDeviceSpec{T<:Real} <: AssetSpec{T}
-    capacity::T
-    energy::T
-    decayrate::T
-    λ::T
-    μ::T
+struct Storages{L,T<:Period,P<:PowerUnit,E<:EnergyUnit} <: AbstractAssets{L,T,P}
+
+    name::Vector{String}
+    category::Vector{String}
+
+    chargecapacity::Matrix{Int} # power
+    dischargecapacity::Matrix{Int} # power
+    energycapacity::Matrix{Int} # energy
+    chargeefficiency::Matrix{Float64}
+    dischargeefficiency::Matrix{Float64}
+    carryoverefficiency::Matrix{Float64}
+
+    λ::Matrix{Float64}
+    μ::Matrix{Float64}
+
+    function Storages{L,T,P,E}(
+        name::Vector{String}, category::Vector{String},
+        chargecapacity::Matrix{Int}, dischargecapacity::Matrix{Int},
+        energycapacity::Matrix{Int}, chargeefficiency::Matrix{Int},
+        dischargeefficiency::Matrix{Float64}, carryoverefficiency::Matrix{Float64},
+        λ::Matrix{Float64}, μ::Matrix{Float64}
+    ) where {L,T,P,E}
+
+        n_stors = length(name)
+        n_periods = size(capacity, 2)
+
+        @assert length(category) == n_gens
+
+        @assert size(chargecapacity) == (n_gens, n_periods)
+        @assert size(dischargecapacity) == (n_gens, n_periods)
+        @assert size(energycapacity) == (n_gens, n_periods)
+        @assert all(chargecapacity .>= 0)
+        @assert all(dischargecapacity .>= 0)
+        @assert all(energycapacity .>= 0)
+
+        @assert size(chargeefficiency) == (n_gens, n_periods)
+        @assert size(dischargeefficiency) == (n_gens, n_periods)
+        @assert size(carryoverefficiency) == (n_gens, n_periods)
+        @assert all(0 .<= chargeefficiency .<= 1)
+        @assert all(0 .<= dischargeefficiency .<= 1)
+        @assert all(0 .<= carryoverefficiency .<= 1)
+
+        @assert size(λ) == (n_gens, n_periods)
+        @assert size(μ) == (n_gens, n_periods)
+        @assert all(0 .<= λ .<= 1)
+        @assert all(0 .<= μ .<= 1)
+
+        new{L,T,P,E}(name, category,
+                     chargecapacity, dischargecapacity, energycapacity,
+                     chargeefficiency, dischargeefficiency, carryoverefficiency,
+                     λ, μ)
+
+    end
+
 end
 
-struct LineSpec{T<:Real} <: AssetSpec{T}
-    capacity::T
-    λ::T
-    μ::T
+struct GeneratorStorages{L,T<:Period,P<:PowerUnit,E<:EnergyUnit} <: AbstractAssets{L,T,P}
+
+    name::Vector{String}
+    category::Vector{String}
+
+    inflowcapacity::Matrix{Int} # power
+    chargecapacity::Matrix{Int} # power
+    dischargecapacity::Matrix{Int} # power
+    storage_chargecapacity::Matrix{Int} # power
+    storage_dischargecapacity::Matrix{Int} # power
+    storage_energycapacity::Matrix{Int} # energy
+    storage_chargeefficiency::Matrix{Float64}
+    storage_dischargeefficiency::Matrix{Float64}
+    storage_carryoverefficiency::Matrix{Float64}
+
+    λ::Matrix{Float64}
+    μ::Matrix{Float64}
+
+    function GeneratorStorages{L,T,P,E}(
+        name::Vector{String}, category::Vector{String}, inflowcapacity::Matrix{Int},
+        chargecapacity::Matrix{Int}, dischargecapacity::Matrix{Int},
+        storage_chargecapacity::Matrix{Int}, storage_dischargecapacity::Matrix{Int},
+        storage_energycapacity::Matrix{Int}, storage_chargeefficiency::Matrix{Int},
+        storage_dischargeefficiency::Matrix{Float64}, storage_carryoverefficiency::Matrix{Float64},
+        λ::Matrix{Float64}, μ::Matrix{Float64}
+    ) where {L,T,P,E}
+
+        n_stors = length(name)
+        n_periods = size(capacity, 2)
+
+        @assert length(category) == n_gens
+
+        @assert size(inflowcapacity) == (n_gens, n_periods)
+        @assert size(chargecapacity) == (n_gens, n_periods)
+        @assert size(dischargecapacity) == (n_gens, n_periods)
+        @assert all(inflowcapacity .>= 0)
+        @assert all(chargecapacity .>= 0)
+        @assert all(dischargecapacity .>= 0)
+
+        @assert size(storage_chargecapacity) == (n_gens, n_periods)
+        @assert size(storage_dischargecapacity) == (n_gens, n_periods)
+        @assert size(storage_energycapacity) == (n_gens, n_periods)
+        @assert all(storage_chargecapacity .>= 0)
+        @assert all(storage_dischargecapacity .>= 0)
+        @assert all(storage_energycapacity .>= 0)
+
+        @assert size(storage_chargeefficiency) == (n_gens, n_periods)
+        @assert size(storage_dischargeefficiency) == (n_gens, n_periods)
+        @assert size(storage_carryoverefficiency) == (n_gens, n_periods)
+        @assert all(0 .<= storage_chargeefficiency .<= 1)
+        @assert all(0 .<= storage_dischargeefficiency .<= 1)
+        @assert all(0 .<= storage_carryoverefficiency .<= 1)
+
+        @assert size(λ) == (n_gens, n_periods)
+        @assert size(μ) == (n_gens, n_periods)
+        @assert all(0 .<= λ .<= 1)
+        @assert all(0 .<= μ .<= 1)
+
+        new{L,T,P,E}(name, category,
+                     inflowcapacity, chargecapacity, dischargecapacity,
+                     storage_chargecapacity, storage_dischargecapacity,
+                     storage_energycapacity,
+                     storage_chargeefficiency, storage_dischargeefficiency,
+                     storage_carryoverefficiency,
+                     λ, μ)
+
+    end
+
+end
+
+struct Lines{L,T<:Period,P<:PowerUnit} <: AbstractAssets{L,T,P}
+
+    name::Vector{String}
+    category::Vector{String}
+
+    forwardcapacity::Matrix{Int} # power
+    backwardcapacity::Matrix{Int} # power
+
+    λ::Matrix{Float64}
+    μ::Matrix{Float64}
+
+    function Lines{L,T,P}(
+        name::Vector{String}, category::Vector{String},
+        forwardcapacity::Matrix{Int}, backwardcapacity::Matrix{Int},
+        λ::Matrix{Float64}, μ::Matrix{Float64}
+    ) where {L,T,P}
+
+        n_gens = length(name)
+        n_periods = size(capacity, 2)
+
+        @assert length(category) == n_gens
+        @assert size(forwardcapacity) == (n_gens, n_periods)
+        @assert size(backwardcapacity) == (n_gens, n_periods)
+        @assert all(forwardcapacity .>= 0)
+        @assert all(backwardcapacity .>= 0)
+
+        @assert size(λ) == (n_gens, n_periods)
+        @assert size(μ) == (n_gens, n_periods)
+        @assert all(0 .<= λ .<= 1)
+        @assert all(0 .<= μ .<= 1)
+
+        new{L,T,P}(name, category, forwardcapacity, backwardcapacity, λ, μ)
+
+    end
+
 end

--- a/src/collections.jl
+++ b/src/collections.jl
@@ -10,6 +10,7 @@ struct Regions{N,P<:PowerUnit}
         n_regions = length(names)
 
         @assert size(load) == (n_regions, N)
+        @assert all(load .>= 0)
 
         new{N,P}(names, load)
 
@@ -17,7 +18,7 @@ struct Regions{N,P<:PowerUnit}
 
 end
 
-length(r::Regions) = length(r.names)
+Base.length(r::Regions) = length(r.names)
 
 struct Interfaces{N,P<:PowerUnit}
 
@@ -36,6 +37,8 @@ struct Interfaces{N,P<:PowerUnit}
 
         @assert size(forwardcapacity) == (n_interfaces, N)
         @assert size(backwardcapacity) == (n_interfaces, N)
+        @assert all(forwardcapacity .>= 0)
+        @assert all(backwardcapacity .>= 0)
 
         new{N,P}(regions_from, regions_to, forwardcapacity, backwardcapacity)
 
@@ -43,4 +46,4 @@ struct Interfaces{N,P<:PowerUnit}
 
 end
 
-length(i::Interfaces) = length(i.regions_from)
+Base.length(i::Interfaces) = length(i.regions_from)

--- a/src/collections.jl
+++ b/src/collections.jl
@@ -1,0 +1,9 @@
+struct Regions{P<:PowerUnit}
+    names::Vector{String}
+    load::Matrix{Int}
+end
+
+struct Interfaces
+    regions_from::Vector{Int}
+    regions_to::Vector{Int}
+end

--- a/src/collections.jl
+++ b/src/collections.jl
@@ -1,9 +1,46 @@
-struct Regions{P<:PowerUnit}
+struct Regions{N,P<:PowerUnit}
+
     names::Vector{String}
     load::Matrix{Int}
+
+    function Regions{N,P}(
+        names::Vector{String}, load::Matrix{Int}
+    ) where {N,P<:PowerUnit}
+
+        n_regions = length(names)
+
+        @assert size(load) == (n_regions, N)
+
+        new{N,P}(names, load)
+
+    end
+
 end
 
-struct Interfaces
+length(r::Regions) = length(r.names)
+
+struct Interfaces{N,P<:PowerUnit}
+
     regions_from::Vector{Int}
     regions_to::Vector{Int}
+    limit_forward::Matrix{Int}
+    limit_backward::Matrix{Int}
+
+    function Interfaces{N,P}(
+        regions_from::Vector{Int}, regions_to::Vector{Int},
+        forwardcapacity::Matrix{Int}, backwardcapacity::Matrix{Int}
+    ) where {N,P<:PowerUnit}
+
+        n_interfaces = length(regions_from)
+        @assert length(regions_to) == n_interfaces
+
+        @assert size(forwardcapacity) == (n_interfaces, N)
+        @assert size(backwardcapacity) == (n_interfaces, N)
+
+        new{N,P}(regions_from, regions_to, forwardcapacity, backwardcapacity)
+
+    end
+
 end
+
+length(i::Interfaces) = length(i.regions_from)

--- a/src/units.jl
+++ b/src/units.jl
@@ -26,8 +26,8 @@ unitsymbol(::Type{Year}) = "y"
 #      in terms of conversions to a common set of units (MW, MWh, Hour?)
 #      and ship all conversions through those?
 
-powertoenergy(p::Real, n::Real, ::Type{Hour}, ::Type{MW}, ::Type{MWh})   = n*p
-powertoenergy(p::Real, n::Real, ::Type{Minute}, ::Type{MW}, ::Type{MWh}) = n*p/60
+powertoenergy(::Type{MWh}, p::Real, ::Type{MW}, n::Real, ::Type{Hour})   = n*p
+powertoenergy(::Type{MWh}, p::Real, ::Type{MW}, n::Real, ::Type{Minute}) = n*p/60
 
-energytopower(e::Real, n::Real, ::Type{Hour}, ::Type{MW}, ::Type{MWh})   = e/n
-energytopower(e::Real, n::Real, ::Type{Minute}, ::Type{MW}, ::Type{MWh}) = e/n*60
+energytopower(::Type{MW}, e::Real, ::Type{MWh}, n::Real, ::Type{Hour})   = e/n
+energytopower(::Type{MW}, e::Real, ::Type{MWh}, n::Real, ::Type{Minute}) = e/n*60

--- a/test/SystemModel.jl
+++ b/test/SystemModel.jl
@@ -1,1 +1,48 @@
+@testset "SystemModel" begin
 
+    generators = Generators{10,1,Hour,MW}(
+        ["Gen A", "Gen B"], ["CC", "CT"],
+        rand(1:10, 2, 10), fill(0.1, 2, 10), fill(0.1, 2, 10))
+
+    storages = Storages{10,1,Hour,MW,MWh}(
+        ["S1", "S2"], ["Battery", "Pumped Hydro"],
+        rand(1:10, 2, 10), rand(1:10, 2, 10), rand(1:10, 2, 10),
+        fill(0.9, 2, 10), fill(1.0, 2, 10), fill(0.99, 2, 10),
+        fill(0.1, 2, 10), fill(0.5, 2, 10))
+
+    generatorstorages = GeneratorStorages{10,1,Hour,MW,MWh}(
+        ["GS1"], ["CSP"],
+        rand(1:10, 1, 10), rand(1:10, 1, 10), rand(1:10, 1, 10),
+        rand(1:10, 1, 10), rand(1:10, 1, 10), rand(1:10, 1, 10),
+        fill(0.9, 1, 10), fill(1.0, 1, 10), fill(0.99, 1, 10),
+        fill(0.1, 1, 10), fill(0.5, 1, 10))
+
+    timestamps = DateTime(2020, 1, 1, 0):Hour(1):DateTime(2020,1,1,9)
+
+    # Single-region constructor
+    SystemModel{10,1,Hour,MW,MWh}(
+        generators, storages, generatorstorages, timestamps, rand(1:20, 10))
+
+    regions = Regions{10,MW}(
+        ["Region A", "Region B"], rand(1:20, 2, 10))
+
+    interfaces = Interfaces{10,MW}(
+        [1], [2], fill(100, 1, 10), fill(100, 1, 10))
+
+    lines = Lines{10,1,Hour,MW}(
+        ["Line 1", "Line 2"], ["Line", "Line"],
+        fill(10, 2, 10), fill(10, 2, 10), fill(0., 2, 10), fill(1.0, 2, 10))
+
+    gen_regions = [1, 2]
+    stor_regions = [1, 1]
+    genstor_regions = [1,2]
+    line_interfaces = [1]
+
+    # Multi-region constructor
+    SystemModel{10,1,Hour,MW,MWh}(
+        regions, generators, storages, generatorstorages,
+        interfaces, lines,
+        gen_regions, stor_regions, genstor_regions, line_interfaces,
+        timestamps)
+
+end

--- a/test/assets.jl
+++ b/test/assets.jl
@@ -1,1 +1,100 @@
+@testset "Assets" begin
 
+    names = ["A1", "A2", "B1"]
+    categories = ["A", "A", "B"]
+
+    vals_int   = rand(1:100, 3, 10)
+    vals_float = rand(3, 10)
+
+    @testset "Generators" begin
+
+        Generators{10,1,Hour,MW}(
+            names, categories, vals_int, vals_float, vals_float)
+
+        @test_throws AssertionError Generators{5,1,Hour,MW}(
+            names, categories, vals_int, vals_float, vals_float)
+
+        @test_throws AssertionError Generators{10,1,Hour,MW}(
+            names[1:2], categories, vals_int, vals_float, vals_float)
+
+        @test_throws AssertionError Generators{10,1,Hour,MW}(
+            names[1:2], categories[1:2], vals_int, vals_float, vals_float)
+
+        @test_throws AssertionError Generators{10,1,Hour,MW}(
+            names, categories, -vals_int, vals_float, vals_float)
+
+    end
+
+    @testset "Storages" begin
+
+        Storages{10,1,Hour,MW,MWh}(
+            names, categories, vals_int, vals_int, vals_int,
+            vals_float, vals_float, vals_float, vals_float, vals_float)
+
+        @test_throws AssertionError Storages{5,1,Hour,MW,MWh}(
+            names, categories, vals_int, vals_int, vals_int,
+            vals_float, vals_float, vals_float, vals_float, vals_float)
+
+        @test_throws AssertionError Storages{10,1,Hour,MW,MWh}(
+            names, categories[1:2], vals_int, vals_int, vals_int,
+            vals_float, vals_float, vals_float, vals_float, vals_float)
+
+        @test_throws AssertionError Storages{10,1,Hour,MW,MWh}(
+            names[1:2], categories[1:2], vals_int, vals_int, vals_int,
+            vals_float, vals_float, vals_float, vals_float, vals_float)
+
+        @test_throws AssertionError Storages{10,1,Hour,MW,MWh}(
+            names, categories, vals_int, vals_int, vals_int,
+            vals_float, vals_float, -vals_float, vals_float, vals_float)
+
+    end
+
+    @testset "GeneratorStorages" begin
+
+        GeneratorStorages{10,1,Hour,MW,MWh}(
+            names, categories,
+            vals_int, vals_int, vals_int, vals_int, vals_int, vals_int,
+            vals_float, vals_float, vals_float, vals_float, vals_float)
+
+        @test_throws AssertionError GeneratorStorages{5,1,Hour,MW,MWh}(
+            names, categories,
+            vals_int, vals_int, vals_int, vals_int, vals_int, vals_int,
+            vals_float, vals_float, vals_float, vals_float, vals_float)
+
+        @test_throws AssertionError GeneratorStorages{10,1,Hour,MW,MWh}(
+            names, categories[1:2],
+            vals_int, vals_int, vals_int, vals_int, vals_int, vals_int,
+            vals_float, vals_float, vals_float, vals_float, vals_float)
+
+        @test_throws AssertionError GeneratorStorages{10,1,Hour,MW,MWh}(
+            names[1:2], categories[1:2],
+            vals_int, vals_int, vals_int, vals_int, vals_int, vals_int,
+            vals_float, vals_float, vals_float, vals_float, vals_float)
+
+        @test_throws AssertionError GeneratorStorages{10,1,Hour,MW,MWh}(
+            names, categories,
+            vals_int, vals_int, vals_int, vals_int, vals_int, vals_int,
+            vals_float, vals_float, -vals_float, vals_float, vals_float)
+
+    end
+
+    @testset "Lines" begin
+
+        Lines{10,1,Hour,MW}(
+            names, categories, vals_int, vals_int, vals_float, vals_float)
+
+        @test_throws AssertionError Lines{5,1,Hour,MW}(
+            names, categories, vals_int, vals_int, vals_float, vals_float)
+
+        @test_throws AssertionError Lines{10,1,Hour,MW}(
+            names[1:2], categories, vals_int, vals_int, vals_float, vals_float)
+
+        @test_throws AssertionError Lines{10,1,Hour,MW}(
+            names[1:2], categories[1:2], vals_int, vals_int, vals_float, vals_float)
+
+        @test_throws AssertionError Lines{10,1,Hour,MW}(
+            names, categories, -vals_int, vals_int, vals_float, vals_float)
+
+    end
+
+end

--- a/test/collections.jl
+++ b/test/collections.jl
@@ -1,0 +1,37 @@
+@testset "Collections" begin
+
+    @testset "Regions" begin
+
+        Regions{10,MW}(["Region A", "Region B"], rand(1:10, 2, 10))
+
+        @test_throws AssertionError Regions{10,MW}(
+            ["Region A", "Region B"], rand(1:10, 2, 5))
+
+        @test_throws AssertionError Regions{10,MW}(
+            ["Region A", "Region B"], rand(1:10, 3, 10))
+
+        @test_throws AssertionError Regions{10,MW}(
+            ["Region A", "Region B"], -rand(1:10, 2, 10))
+
+    end
+
+    @testset "Interfaces" begin
+
+        Interfaces{10,MW}(
+            [1,1,2], [2,3,3], rand(1:15, 3, 10), rand(1:15, 3, 10))
+
+        @test_throws AssertionError Interfaces{10,MW}(
+            [1,1,2], [2,3], rand(1:15, 3, 10), rand(1:15, 3, 10))
+
+        @test_throws AssertionError Interfaces{10,MW}(
+            [1,1,2], [2,3,3], rand(1:15, 2, 10), rand(1:15, 2, 10))
+
+        @test_throws AssertionError Interfaces{10,MW}(
+            [1,1,2], [2,3,3], rand(1:15, 3, 11), rand(1:15, 3, 11))
+
+        @test_throws AssertionError Interfaces{10,MW}(
+            [1,1,2], [2,3,3], rand(1:15, 3, 10), -rand(1:15, 3, 10))
+
+    end
+
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,11 +1,11 @@
 using Test
 using PRASBase
-using Dates
 
 @testset "PRASBase" begin
 
     include("units.jl")
     include("assets.jl")
+    include("collections.jl")
     include("SystemModel.jl")
 
 end

--- a/test/units.jl
+++ b/test/units.jl
@@ -1,1 +1,9 @@
+@testset "Units and Conversions" begin
 
+    @test powertoenergy(MWh, 10, MW, 2, Hour) == 20
+    @test powertoenergy(MWh, 10, MW, 30, Minute) == 5
+
+    @test energytopower(MW, 100, MWh, 10, Hour) == 10
+    @test energytopower(MW, 100, MWh, 30, Minute) == 200
+
+end


### PR DESCRIPTION
Revamp asset representation such that all properties are considered time-varying. This eliminates the distinction between dispatchable and variable generation: variable generation is just a generator with a time-varying maximum capacity. This also allows associating random outages with VG.

Also introduces the GeneratorStorage asset, which defines some exogenous power inflow which can be either injected to the grid or used to charge a coupled storage device. The grid interface and storage device can have independent charge/dischage limits (for example, this can represent a battery discharge capacity that is separate from the installation's inverter size).

Closes #1, closes #2, and closes #3.